### PR TITLE
Modify interface to enable usage in an Obj-C project

### DIFF
--- a/FloatRatingView.swift
+++ b/FloatRatingView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol FloatRatingViewDelegate {
+@objc public protocol FloatRatingViewDelegate {
     /**
     Returns the rating value when touch events end
     */
@@ -23,11 +23,11 @@ protocol FloatRatingViewDelegate {
 /**
 A simple rating view that can set whole, half or floating point ratings.
 */
-class FloatRatingView: UIView {
+public class FloatRatingView: UIView {
     
     // MARK: Float Rating View properties
     
-    var delegate: FloatRatingViewDelegate?
+    public var delegate: FloatRatingViewDelegate?
     
     /**
     Array of empty image views
@@ -42,7 +42,7 @@ class FloatRatingView: UIView {
     /**
     Sets the empty image (e.g. a star outline)
     */
-    var emptyImage: UIImage? {
+    public var emptyImage: UIImage? {
         didSet {
             // Update empty image views
             for imageView in self.emptyImageViews {
@@ -56,7 +56,7 @@ class FloatRatingView: UIView {
     Sets the full image that is overlayed on top of the empty image.
     Should be same size and shape as the empty image.
     */
-    var fullImage: UIImage? {
+    public var fullImage: UIImage? {
         didSet {
             // Update full image views
             for imageView in self.fullImageViews {
@@ -74,7 +74,7 @@ class FloatRatingView: UIView {
     /**
     Minimum rating.
     */
-    var minRating: Int  = 0 {
+    public var minRating: Int  = 0 {
         didSet {
             // Update current rating if needed
             if self.rating < Float(minRating) {
@@ -87,7 +87,7 @@ class FloatRatingView: UIView {
     /**
     Max rating value.
     */
-    var maxRating: Int = 5 {
+    public var maxRating: Int = 5 {
         didSet {
             let needsRefresh = maxRating != oldValue
             
@@ -105,12 +105,12 @@ class FloatRatingView: UIView {
     /**
     Minimum image size.
     */
-    var minImageSize: CGSize = CGSize(width: 5.0, height: 5.0)
+    public var minImageSize: CGSize = CGSize(width: 5.0, height: 5.0)
     
     /**
     Set the current rating.
     */
-    var rating: Float = 0 {
+    public var rating: Float = 0 {
         didSet {
             if rating != oldValue {
                 self.refresh()
@@ -121,28 +121,28 @@ class FloatRatingView: UIView {
     /**
     Sets whether or not the rating view can be changed by panning.
     */
-    var editable: Bool = true
+    public var editable: Bool = true
     
     /**
     Ratings change by 0.5. Takes priority over floatRatings property.
     */
-    var halfRatings: Bool = false
+    public var halfRatings: Bool = false
     
     /**
     Ratings change by floating point values.
     */
-    var floatRatings: Bool = false
+    public var floatRatings: Bool = false
     
     
     // MARK: Initializations
     
-    required override init(frame: CGRect) {
+    required override public init(frame: CGRect) {
         super.init(frame: frame)
         
         self.initImageViews()
     }
     
-    required init(coder aDecoder: NSCoder) {
+    required public init(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         
         self.initImageViews()
@@ -195,7 +195,7 @@ class FloatRatingView: UIView {
     }
     
     // Override to calculate ImageView frames
-    override func layoutSubviews() {
+    override public func layoutSubviews() {
         super.layoutSubviews()
         
         if let emptyImage = self.emptyImage {
@@ -293,21 +293,21 @@ class FloatRatingView: UIView {
         }
     }
     
-    override func touchesBegan(touches: NSSet, withEvent event: UIEvent) {
+    override public func touchesBegan(touches: NSSet, withEvent event: UIEvent) {
         if let touch = touches.anyObject() as? UITouch {
             let touchLocation = touch.locationInView(self)
             self.handleTouchAtLocation(touchLocation)
         }
     }
     
-    override func touchesMoved(touches: NSSet, withEvent event: UIEvent) {
+    override public func touchesMoved(touches: NSSet, withEvent event: UIEvent) {
         if let touch = touches.anyObject() as? UITouch {
             let touchLocation = touch.locationInView(self)
             self.handleTouchAtLocation(touchLocation)
         }
     }
     
-    override func touchesEnded(touches: NSSet, withEvent event: UIEvent) {
+    override public func touchesEnded(touches: NSSet, withEvent event: UIEvent) {
         // Update delegate
         if let delegate = self.delegate {
             delegate.floatRatingView(self, didUpdate: self.rating)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Usage
 
 Initialize from a nib/xib or programmatically. Set the empty and full image, then you're pretty much good to go! Check out the demo app to see how it can be used.
 
+Usage in an Objective-C Project
+-------------------------------
+ 1. Import the Swift File
+ 2. Ensure the build settings in your project are set to enable Swift usage (see [here](http://stackoverflow.com/questions/25774085/xcode-gm-ios-8-gm-swift-today-extension-crash-in-simulator-and-device-library-n) and [here](http://stackoverflow.com/questions/24002836/dyld-library-not-loaded-rpath-libswift-stdlib-core-dylib/25247890#25247890))
+ 3. `import "YOUR_PROJECT_NAME-Swift.h"` in your Objective-C files where you want to use `FloatRatingView`
+
 How it works
 ------------
 


### PR DESCRIPTION
Must declare public interfaces & annotate protocol w/ `@objc` in order to use this control in Objective C projects through the auto generated header file.
