### PR TITLE
Prepare Podspec for Submission to CocoaPods

### DIFF
--- a/FloatRatingView.podspec
+++ b/FloatRatingView.podspec
@@ -1,12 +1,13 @@
 Pod::Spec.new do |spec|
-	spec.name = 'FloatRatingView'
-	spec.version = '1.0.1'
-	spec.summary = 'Whole, half or floating point ratings control written in Swift.'
-	spec.homepage = 'https://github.com/strekfus/FloatRatingView'
-	spec.license = 'MIT'
-	spec.author = { 'Glen Yi' => 'glenyi81@gmail.com' }
+	spec.name 						= 'FloatRatingView'
+	spec.version 					= '1.0.1'
+	spec.summary 					= 'Whole, half or floating point ratings control written in Swift.'
+	spec.homepage 				= 'https://github.com/strekfus/FloatRatingView'
+	spec.license 					= 'MIT'
+	spec.author 					= { 'Glen Yi' => 'glenyi81@gmail.com' }
 	spec.social_media_url = 'https://twitter.com/glenyi'
-	spec.source = { :git => 'https://github.com/strekfus/FloatRatingView.git', :tag => "#{spec.version}" }
-	spec.source_files = 'FloatRatingView.swift'
-	spec.requires_arc = true
+	spec.source 					= { :git => 'https://github.com/strekfus/FloatRatingView.git', :tag => "#{spec.version}" }
+	spec.source_files 		= 'FloatRatingView.swift'
+	spec.platform 				= :ios, '8.0'
+	spec.requires_arc 		= true
 end

--- a/FloatRatingView.podspec
+++ b/FloatRatingView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
 	spec.name 						= 'FloatRatingView'
-	spec.version 					= '1.0.1'
+	spec.version 					= '1.0.2'
 	spec.summary 					= 'Whole, half or floating point ratings control written in Swift.'
 	spec.homepage 				= 'https://github.com/strekfus/FloatRatingView'
 	spec.license 					= 'MIT'

--- a/Rating Demo/Rating Demo.xcodeproj/project.pbxproj
+++ b/Rating Demo/Rating Demo.xcodeproj/project.pbxproj
@@ -341,7 +341,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = "Rating Demo/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.onthepursuit.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -354,7 +354,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = "Rating Demo/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.onthepursuit.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Per #10, it would be great to submit this library directly to CocoaPods. I'm happy to help with that if needed! As a start, I ran `pod lib lint` and resolved the warnings being produced. Primarily, we needed to bump the deployment target to 8.0 to support dynamic frameworks. Please, @glenyi, let me know if you wanted any help putting this on CocoaPods!