### PR TITLE
Correct problem not update the delegate

### DIFF
--- a/FloatRatingView.swift
+++ b/FloatRatingView.swift
@@ -311,4 +311,8 @@ open class FloatRatingView: UIView {
         delegate?.floatRatingView(self, didUpdate: rating)
     }
     
+    override open func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        // Update delegate
+        delegate?.floatRatingView(self, didUpdate: rating)
+    }
 }


### PR DESCRIPTION
Sometimes the method touchesEnded was not called because the user not moved the finger.
With the touchesCancelled method the library can read when the user tap the screen and remove his finger without move.